### PR TITLE
Fix up set literals with `in`

### DIFF
--- a/test/corpus/formula.txt
+++ b/test/corpus/formula.txt
@@ -60,6 +60,17 @@ select i
    (in_expr (variable (varName (simpleId))) (range (literal (integer)) (literal (integer))))
    (asExprs (asExpr (variable (varName (simpleId))))))))
 
+=====
+set literals
+=====
+
+from int i
+where i in [1, 2]
+select i
+
+---
+
+
 =================
 predicateRef call
 =================


### PR DESCRIPTION
@p0 noticed that some CodeQL was failing to parse and we narrowed it down to the following usage of set literals with an `in` expression. Fix is todo, this just demonstrates a failing test.