### PR TITLE
Add "implements" to keyword list

### DIFF
--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -16,6 +16,7 @@
   "forex"
   "from"
   "if"
+  "implements"
   "implies"
   "import"
   "in"


### PR DESCRIPTION
Adds the `implements` keyword to `highlights.scm`.